### PR TITLE
Use sparklyr rather than sparkapi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .Rhistory
 .RData
 .Ruserdata
+derby.log*
+log4j.*

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,7 @@ URL: https://github.com/bnosac/spark.sas7bdat
 Date: 2016-07-20
 VignetteBuilder: knitr
 Imports:
-    sparkapi,
-    sparklyr,
+    sparklyr (>= 0.3),
     magrittr
 Suggests:
     knitr

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,8 +2,8 @@
 
 export(spark_read_sas)
 importFrom(magrittr,"%>%")
-importFrom(sparkapi,hive_context)
-importFrom(sparkapi,invoke)
-importFrom(sparkapi,register_extension)
-importFrom(sparkapi,spark_dependency)
+importFrom(sparklyr,hive_context)
+importFrom(sparklyr,invoke)
+importFrom(sparklyr,register_extension)
 importFrom(sparklyr,sdf_register)
+importFrom(sparklyr,spark_dependency)

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -3,7 +3,6 @@
 #' @name spark.sas7bdat-package 
 #' @aliases spark.sas7bdat-package
 #' @docType package 
-#' @importFrom sparkapi hive_context invoke spark_dependency register_extension
-#' @importFrom sparklyr sdf_register
+#' @importFrom sparklyr hive_context invoke spark_dependency register_extension sdf_register
 #' @importFrom magrittr "%>%"
 NULL

--- a/R/read_sas.R
+++ b/R/read_sas.R
@@ -8,7 +8,7 @@
 #' @return an object of class \code{tbl_spark}, which is a reference to a Spark DataFrame based on which
 #' dplyr functions can be executed. See \url{https://github.com/rstudio/sparklyr}
 #' @export
-#' @seealso \code{\link[sparklyr]{start_shell}}, \code{\link[sparklyr]{sdf_register}}
+#' @seealso \code{\link[sparklyr]{spark_connect}}, \code{\link[sparklyr]{sdf_register}}
 #' @references \url{https://spark-packages.org/package/saurfang/spark-sas7bdat}, \url{https://github.com/saurfang/spark-sas7bdat}, \url{https://github.com/rstudio/sparklyr}
 #' @examples
 #' \dontrun{

--- a/R/read_sas.R
+++ b/R/read_sas.R
@@ -8,15 +8,15 @@
 #' @return an object of class \code{tbl_spark}, which is a reference to a Spark DataFrame based on which
 #' dplyr functions can be executed. See \url{https://github.com/rstudio/sparklyr}
 #' @export
-#' @seealso \code{\link[sparkapi]{start_shell}}, \code{\link[sparklyr]{sdf_register}}
-#' @references \url{https://spark-packages.org/package/saurfang/spark-sas7bdat}, \url{https://github.com/saurfang/spark-sas7bdat}, \url{https://github.com/rstudio/sparkapi}, \url{https://github.com/rstudio/sparklyr}
+#' @seealso \code{\link[sparklyr]{start_shell}}, \code{\link[sparklyr]{sdf_register}}
+#' @references \url{https://spark-packages.org/package/saurfang/spark-sas7bdat}, \url{https://github.com/saurfang/spark-sas7bdat}, \url{https://github.com/rstudio/sparklyr}
 #' @examples
 #' \dontrun{
 #' myfile <- system.file("extdata", "iris.sas7bdat", package = "spark.sas7bdat")
 #' myfile
 #' 
-#' library(spark.sas7bdat)
 #' library(sparklyr)
+#' library(spark.sas7bdat)
 #' sc <- spark_connect(master = "local")
 #' x <- spark_read_sas(sc, path = myfile, table = "sas_example")
 #' x
@@ -35,12 +35,12 @@ spark_read_sas <- function(sc, path, table){
 
 
 spark_dependencies <- function(scala_version, ...) {
-  sparkapi::spark_dependency(
+  sparklyr::spark_dependency(
     packages = c(
       sprintf("saurfang:spark-sas7bdat:1.1.4-s_%s", scala_version)
     )
   )
 }
 .onLoad <- function(libname, pkgname) {
-  sparkapi::register_extension(pkgname)
+  sparklyr::register_extension(pkgname)
 }

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The  **spark.sas7bdat** package allows R users working with [Apache Spark](https
 ## Example
 The following example reads in a file called iris.sas7bdat in parallel in a table called sas_example in Spark. Do try this with bigger data on your cluster and look at the help of the [sparklyr](https://github.com/rstudio/sparklyr) package to connect to your Spark cluster.
 
-```
-library(spark.sas7bdat)
+```r
 library(sparklyr)
+library(spark.sas7bdat)
 mysasfile <- system.file("extdata", "iris.sas7bdat", package = "spark.sas7bdat")
 
 sc <- spark_connect(master = "local")
@@ -17,9 +17,8 @@ x
 ```
 
 The resulting pointer to a Spark table can be further used in dplyr statements
-```
+```r
 library(dplyr)
-library(magrittr)
 x %>% group_by(Species) %>%
   summarise(count = n(), length = mean(Sepal_Length), width = mean(Sepal_Width))
 ```
@@ -35,7 +34,7 @@ vignette("spark_sas7bdat_examples", package = "spark.sas7bdat")
 
 In order to compare the functionality to the read_sas function from the [haven](https://cran.r-project.org/web/packages/haven/index.html) package, below we show a comparison on a small 5234557 rows x 2 columns SAS dataset with only numeric data. Imported on 8 cores.
 
-```
+```r
 mysasfile <- "/home/bnosac/Desktop/testdata.sas7bdat"
 system.time(x <- spark_read_sas(sc, path = mysasfile, table = "testdata"))
    user  system elapsed 

--- a/man/spark_read_sas.Rd
+++ b/man/spark_read_sas.Rd
@@ -9,7 +9,8 @@ spark_read_sas(sc, path, table)
 \arguments{
 \item{sc}{Connection to Spark local instance or remote cluster. See the example}
 
-\item{path}{path to the SAS file either on HDFS (hdfs://), S3 (s3n://), as well as the local file system (file://).}
+\item{path}{full path to the SAS file either on HDFS (hdfs://), S3 (s3n://), as well as the local file system (file://). 
+Mark that files on the local file system need to be specified using the full path.}
 
 \item{table}{character string with the name of the Spark table where the SAS dataset will be put into}
 }
@@ -25,17 +26,17 @@ Read in SAS datasets in .sas7bdat format into Spark by using the spark-sas7bdat 
 myfile <- system.file("extdata", "iris.sas7bdat", package = "spark.sas7bdat")
 myfile
 
-library(spark.sas7bdat)
 library(sparklyr)
+library(spark.sas7bdat)
 sc <- spark_connect(master = "local")
 x <- spark_read_sas(sc, path = myfile, table = "sas_example")
 x
 }
 }
 \references{
-\url{https://spark-packages.org/package/saurfang/spark-sas7bdat}, \url{https://github.com/saurfang/spark-sas7bdat}, \url{https://github.com/rstudio/sparkapi}, \url{https://github.com/rstudio/sparklyr}
+\url{https://spark-packages.org/package/saurfang/spark-sas7bdat}, \url{https://github.com/saurfang/spark-sas7bdat}, \url{https://github.com/rstudio/sparklyr}
 }
 \seealso{
-\code{\link[sparkapi]{start_shell}}, \code{\link[sparklyr]{sdf_register}}
+\code{\link[sparklyr]{start_shell}}, \code{\link[sparklyr]{sdf_register}}
 }
 

--- a/man/spark_read_sas.Rd
+++ b/man/spark_read_sas.Rd
@@ -37,6 +37,6 @@ x
 \url{https://spark-packages.org/package/saurfang/spark-sas7bdat}, \url{https://github.com/saurfang/spark-sas7bdat}, \url{https://github.com/rstudio/sparklyr}
 }
 \seealso{
-\code{\link[sparklyr]{start_shell}}, \code{\link[sparklyr]{sdf_register}}
+\code{\link[sparklyr]{spark_connect}}, \code{\link[sparklyr]{sdf_register}}
 }
 

--- a/vignettes/spark_sas7bdat_examples.Rmd
+++ b/vignettes/spark_sas7bdat_examples.Rmd
@@ -12,19 +12,19 @@ vignette: >
 This R package allows R users to easily import large [SAS](http://www.sas.com) datasets into [Spark](https://spark.apache.org) tables in parallel.
 
 
-The package uses the [spark-sas7bdat Spark package](https://spark-packages.org/package/saurfang/spark-sas7bdat) in order to read a SAS dataset in Spark. That Spark package imports the data in parallel on the Spark cluster using the Parso library and this process is launched from R using the [sparkapi](https://github.com/rstudio/sparkapi) functionality. 
+The package uses the [spark-sas7bdat Spark package](https://spark-packages.org/package/saurfang/spark-sas7bdat) in order to read a SAS dataset in Spark. That Spark package imports the data in parallel on the Spark cluster using the Parso library and this process is launched from R using the [sparklyr](https://github.com/rstudio/sparklyr) functionality. 
 
-More information about the spark-sas7bdat Spark package and the sparkapi can be found at:
+More information about the spark-sas7bdat Spark package and sparklyr can be found at:
 
 - https://spark-packages.org/package/saurfang/spark-sas7bdat and https://github.com/saurfang/spark-sas7bdat
-- https://github.com/rstudio/sparkapi and https://github.com/rstudio/sparklyr
+- https://github.com/rstudio/sparklyr
 
 ## Example
 The following example reads in a file called iris.sas7bdat in parallel in a table called sas_example in Spark. Do try this with bigger data on your cluster and look at the help of the [sparklyr](https://github.com/rstudio/sparklyr) package to connect to your Spark cluster.
 
 ```{r, eval=FALSE}
-library(spark.sas7bdat)
 library(sparklyr)
+library(spark.sas7bdat)
 mysasfile <- system.file("extdata", "iris.sas7bdat", package = "spark.sas7bdat")
 
 sc <- spark_connect(master = "local")


### PR DESCRIPTION
We've merged the sparkapi package into the sparklyr package (it was unwieldy and fragile to have two packages). This PR imports the requisite API functions from sparklyr rather than sparkapi.

Some other minor tweaks were made including additions to .gitignore, changing the order of library calls to be more consistent with our extensions documentation, and adding R syntax highlighting to the README.md.
