### PR TITLE
Update repositories parameter in spark_dependency

### DIFF
--- a/R/read_sas.R
+++ b/R/read_sas.R
@@ -45,7 +45,8 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
   sparklyr::spark_dependency(
     packages = c(
       sprintf("saurfang:spark-sas7bdat:2.0.0-s_%s", scala_version)
-    )
+    ),
+    repositories = "https://repos.spark-packages.org/"
   )
 }
 .onLoad <- function(libname, pkgname) {


### PR DESCRIPTION
I have had an issue with sparklyr and this package and I believe it is related the repositories parameter in the spark_dependency. The default repositories in sparklyr (spark) do not include the URL for the spark sas7bdat package, and hence the package is not found and spark terminates. The sparklyr log wasn't so informative other than suggesting the package wasn't found. When I ran the spark code in cmd, it clearly showed the attempts at downloading the package online but not from the correct repository.
